### PR TITLE
Updated settings.js to address Issue #10 on VulnTool Extension repo.

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -6,18 +6,31 @@ document.addEventListener("DOMContentLoaded", function () {
     chrome.tabs.update({ url: "popup.html" });
   });
 
-  // Function to initialize checkboxes based on enabled data sources
+  const checkboxes = document.querySelectorAll("input[type='checkbox']");
+  const submitButton = document.getElementById("submit-btn");
+
+  // Function to check if any data sources are selected
+  function updateSubmitButtonState() {
+    const isAnyChecked = Array.from(checkboxes).some(checkbox => checkbox.checked);
+    submitButton.disabled = !isAnyChecked;
+    if (!isAnyChecked) {
+      showNotification("warning", "Please select at least one data source.");
+    }
+  }
+
+  // Initialize checkboxes based on enabled data sources
   function initializeCheckboxes(enabledDataSources) {
-    const checkboxes = document.querySelectorAll("input[type='checkbox']");
     checkboxes.forEach((checkbox) => {
       const label = checkbox.parentElement.textContent.trim();
       if (enabledDataSources.includes(label.toLowerCase().replace(" ", "_"))) {
         checkbox.checked = true;
       }
+      checkbox.addEventListener('change', updateSubmitButtonState); // Add this line
     });
+    updateSubmitButtonState(); // Ensure correct initial state of the Submit button
   }
 
-  // Function to initialize API keys by their values
+  // Initialize API keys by their values
   function initializeApiKeys(apiKeys) {
     const gitHubTokenField = document.getElementById("github-api-key");
     const vulnerableCodeTokenField = document.getElementById(
@@ -66,10 +79,8 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   });
 
-  const submitButton = document.getElementById("submit-btn");
   submitButton.addEventListener("click", () => {
     const checkedDataSources = [];
-    const checkboxes = document.querySelectorAll("input[type='checkbox']");
     checkboxes.forEach((checkbox) => {
       if (checkbox.checked) {
         const label = checkbox.parentElement.textContent.trim();


### PR DESCRIPTION
This Pull Request addresses issue #10 where the extension was allowing submission even when no data sources were selected. This behavior led to unnecessary API calls and an indefinite loading state, negatively impacting the user experience and potentially causing unauthorized requests, as observed with the GitHub API mentioned in issue #10 .

#### Key Changes:
1. **Submit Button State Management**:
   - The "Submit" button is now conditionally enabled based on whether at least one data source checkbox is checked. This prevents the user from submitting the form without selecting any data sources, which aligns with the expected behavior of the application.

2. **User Feedback**:
   - A notification is triggered when the "Submit" button is disabled due to no data sources being selected. This provides clear feedback to the user, helping to correct their actions without confusion.

3. **Code Enhancements**:
   - Added `updateSubmitButtonState` function to check the state of data source selections and update the button's enabled state accordingly.
   - Integrated this check into the checkbox initialization and change events, ensuring that the button's state is always in sync with the form selections.

#### Benefits:
- **Prevents Unnecessary API Calls**: Ensures that API requests are only made when valid data sources are selected, conserving resources and adhering to API usage policies.
- **Improves User Experience**: Provides immediate feedback to users, helping them understand the need to select at least one data source before proceeding.


#### Steps to Test:
1. Navigate to the settings page of the VulnTotal Browser Extension.
2. Attempt to deselect all data sources and submit the form.
3. Observe that the "Submit" button is disabled, and a notification prompts the selection of at least one data source.
4. Select one or more data sources and verify that the "Submit" button becomes enabled.

#### Before:

![Screenshot 2024-12-17 024442](https://github.com/user-attachments/assets/c946f571-08f5-4775-8542-6c9ceba794c8)

#### After:

![Screenshot 2024-12-18 040537](https://github.com/user-attachments/assets/026d1cc1-9b47-493c-8852-b804a90e346b)

